### PR TITLE
Implement new numpy like syntax

### DIFF
--- a/pyiron_lammps/parallel.py
+++ b/pyiron_lammps/parallel.py
@@ -112,28 +112,37 @@ def optimize_structure_parallel(structure_list, potential_dataframe_list, cores=
                 return _parallel_execution(
                     function=_optimize_structure_serial,
                     input_parameter_lst=[
-                        [structure, potential] for structure, potential in zip(structure_list, potential_dataframe_list)
+                        [structure, potential]
+                        for structure, potential in zip(
+                            structure_list, potential_dataframe_list
+                        )
                     ],
                     cores=cores,
                 )
             else:
-                raise ValueError("Input lists have len(structure_list) != len(potential_dataframe_list) .")
+                raise ValueError(
+                    "Input lists have len(structure_list) != len(potential_dataframe_list) ."
+                )
         elif isinstance(potential_dataframe_list, DataFrame):
             return _parallel_execution(
                 function=_optimize_structure_serial,
                 input_parameter_lst=[
-                    [structure, potential_dataframe_list] for structure in structure_list
+                    [structure, potential_dataframe_list]
+                    for structure in structure_list
                 ],
                 cores=cores,
             )
         else:
-            raise TypeError("potential_dataframe_list should either be an pandas.DataFrame object or a list of those. ")
+            raise TypeError(
+                "potential_dataframe_list should either be an pandas.DataFrame object or a list of those. "
+            )
     elif isinstance(structure_list, Atoms):
         if isinstance(potential_dataframe_list, (list, np.ndarray)):
             return _parallel_execution(
                 function=_optimize_structure_serial,
                 input_parameter_lst=[
-                    [structure_list, potential] for potential in potential_dataframe_list
+                    [structure_list, potential]
+                    for potential in potential_dataframe_list
                 ],
                 cores=cores,
             )
@@ -144,9 +153,13 @@ def optimize_structure_parallel(structure_list, potential_dataframe_list, cores=
                 potential_dataframe=potential_dataframe_list,
             )
         else:
-            raise TypeError("potential_dataframe_list should either be an pandas.DataFrame object or a list of those. ")
+            raise TypeError(
+                "potential_dataframe_list should either be an pandas.DataFrame object or a list of those. "
+            )
     else:
-        raise TypeError("structure_list should either be an ase.atoms.Atoms object or a list of those.")
+        raise TypeError(
+            "structure_list should either be an ase.atoms.Atoms object or a list of those."
+        )
 
 
 def calculate_elastic_constants_parallel(
@@ -164,30 +177,57 @@ def calculate_elastic_constants_parallel(
                 return _parallel_execution(
                     function=_calculate_elastic_constants_serial,
                     input_parameter_lst=[
-                        [structure, potential, num_of_point, eps_range, sqrt_eta, fit_order]
-                        for structure, potential in zip(structure_list, potential_dataframe_list)
+                        [
+                            structure,
+                            potential,
+                            num_of_point,
+                            eps_range,
+                            sqrt_eta,
+                            fit_order,
+                        ]
+                        for structure, potential in zip(
+                            structure_list, potential_dataframe_list
+                        )
                     ],
                     cores=cores,
                 )
             else:
-                raise ValueError("Input lists have len(structure_list) != len(potential_dataframe_list) .")
+                raise ValueError(
+                    "Input lists have len(structure_list) != len(potential_dataframe_list) ."
+                )
         elif isinstance(potential_dataframe_list, DataFrame):
             return _parallel_execution(
                 function=_calculate_elastic_constants_serial,
                 input_parameter_lst=[
-                    [structure, potential_dataframe_list, num_of_point, eps_range, sqrt_eta, fit_order]
+                    [
+                        structure,
+                        potential_dataframe_list,
+                        num_of_point,
+                        eps_range,
+                        sqrt_eta,
+                        fit_order,
+                    ]
                     for structure in structure_list
                 ],
                 cores=cores,
             )
         else:
-            raise TypeError("potential_dataframe_list should either be an pandas.DataFrame object or a list of those. ")
+            raise TypeError(
+                "potential_dataframe_list should either be an pandas.DataFrame object or a list of those. "
+            )
     elif isinstance(structure_list, Atoms):
         if isinstance(potential_dataframe_list, (list, np.ndarray)):
             return _parallel_execution(
                 function=_calculate_elastic_constants_serial,
                 input_parameter_lst=[
-                    [structure_list, potential, num_of_point, eps_range, sqrt_eta, fit_order]
+                    [
+                        structure_list,
+                        potential,
+                        num_of_point,
+                        eps_range,
+                        sqrt_eta,
+                        fit_order,
+                    ]
                     for potential in potential_dataframe_list
                 ],
                 cores=cores,
@@ -203,9 +243,13 @@ def calculate_elastic_constants_parallel(
                 fit_order=fit_order,
             )
         else:
-            raise TypeError("potential_dataframe_list should either be an pandas.DataFrame object or a list of those. ")
+            raise TypeError(
+                "potential_dataframe_list should either be an pandas.DataFrame object or a list of those. "
+            )
     else:
-        raise TypeError("structure_list should either be an ase.atoms.Atoms object or a list of those.")
+        raise TypeError(
+            "structure_list should either be an ase.atoms.Atoms object or a list of those."
+        )
 
 
 def calculate_elastic_constants_with_minimization_parallel(
@@ -223,30 +267,57 @@ def calculate_elastic_constants_with_minimization_parallel(
                 return _parallel_execution(
                     function=_calculate_elastic_constants_with_minimization_serial,
                     input_parameter_lst=[
-                        [structure, potential, num_of_point, eps_range, sqrt_eta, fit_order]
-                        for structure, potential in zip(structure_list, potential_dataframe_list)
+                        [
+                            structure,
+                            potential,
+                            num_of_point,
+                            eps_range,
+                            sqrt_eta,
+                            fit_order,
+                        ]
+                        for structure, potential in zip(
+                            structure_list, potential_dataframe_list
+                        )
                     ],
                     cores=cores,
                 )
             else:
-                raise ValueError("Input lists have len(structure_list) != len(potential_dataframe_list) .")
+                raise ValueError(
+                    "Input lists have len(structure_list) != len(potential_dataframe_list) ."
+                )
         elif isinstance(potential_dataframe_list, DataFrame):
             return _parallel_execution(
                 function=_calculate_elastic_constants_with_minimization_serial,
                 input_parameter_lst=[
-                    [structure, potential_dataframe_list, num_of_point, eps_range, sqrt_eta, fit_order]
+                    [
+                        structure,
+                        potential_dataframe_list,
+                        num_of_point,
+                        eps_range,
+                        sqrt_eta,
+                        fit_order,
+                    ]
                     for structure in structure_list
                 ],
                 cores=cores,
             )
         else:
-            raise TypeError("potential_dataframe_list should either be an pandas.DataFrame object or a list of those. ")
+            raise TypeError(
+                "potential_dataframe_list should either be an pandas.DataFrame object or a list of those. "
+            )
     elif isinstance(structure_list, Atoms):
         if isinstance(potential_dataframe_list, (list, np.ndarray)):
             return _parallel_execution(
                 function=_calculate_elastic_constants_with_minimization_serial,
                 input_parameter_lst=[
-                    [structure_list, potential, num_of_point, eps_range, sqrt_eta, fit_order]
+                    [
+                        structure_list,
+                        potential,
+                        num_of_point,
+                        eps_range,
+                        sqrt_eta,
+                        fit_order,
+                    ]
                     for potential in potential_dataframe_list
                 ],
                 cores=cores,
@@ -262,6 +333,10 @@ def calculate_elastic_constants_with_minimization_parallel(
                 fit_order=fit_order,
             )
         else:
-            raise TypeError("potential_dataframe_list should either be an pandas.DataFrame object or a list of those. ")
+            raise TypeError(
+                "potential_dataframe_list should either be an pandas.DataFrame object or a list of those. "
+            )
     else:
-        raise TypeError("structure_list should either be an ase.atoms.Atoms object or a list of those.")
+        raise TypeError(
+            "structure_list should either be an ase.atoms.Atoms object or a list of those."
+        )

--- a/pyiron_lammps/parallel.py
+++ b/pyiron_lammps/parallel.py
@@ -1,6 +1,6 @@
 import numpy as np
 from ase.atoms import Atoms
-from pandas import DataFrame
+from pandas import DataFrame, Series
 from pympipool import Pool
 from pyiron_lammps.wrapper import PyironLammpsLibrary
 from pyiron_lammps.calculation import (
@@ -123,7 +123,7 @@ def optimize_structure_parallel(structure_list, potential_dataframe_list, cores=
                 raise ValueError(
                     "Input lists have len(structure_list) != len(potential_dataframe_list) ."
                 )
-        elif isinstance(potential_dataframe_list, DataFrame):
+        elif isinstance(potential_dataframe_list, (DataFrame, Series)):
             return _parallel_execution(
                 function=_optimize_structure_serial,
                 input_parameter_lst=[
@@ -146,7 +146,7 @@ def optimize_structure_parallel(structure_list, potential_dataframe_list, cores=
                 ],
                 cores=cores,
             )
-        elif isinstance(potential_dataframe_list, DataFrame):
+        elif isinstance(potential_dataframe_list, (DataFrame, Series)):
             return optimize_structure(
                 lmp=_get_lammps_mpi(enable_mpi=False),
                 structure=structure_list,
@@ -195,7 +195,7 @@ def calculate_elastic_constants_parallel(
                 raise ValueError(
                     "Input lists have len(structure_list) != len(potential_dataframe_list) ."
                 )
-        elif isinstance(potential_dataframe_list, DataFrame):
+        elif isinstance(potential_dataframe_list, (DataFrame, Series)):
             return _parallel_execution(
                 function=_calculate_elastic_constants_serial,
                 input_parameter_lst=[
@@ -232,7 +232,7 @@ def calculate_elastic_constants_parallel(
                 ],
                 cores=cores,
             )
-        elif isinstance(potential_dataframe_list, DataFrame):
+        elif isinstance(potential_dataframe_list, (DataFrame, Series)):
             return calculate_elastic_constants(
                 lmp=_get_lammps_mpi(enable_mpi=False),
                 structure=structure_list,
@@ -285,7 +285,7 @@ def calculate_elastic_constants_with_minimization_parallel(
                 raise ValueError(
                     "Input lists have len(structure_list) != len(potential_dataframe_list) ."
                 )
-        elif isinstance(potential_dataframe_list, DataFrame):
+        elif isinstance(potential_dataframe_list, (DataFrame, Series)):
             return _parallel_execution(
                 function=_calculate_elastic_constants_with_minimization_serial,
                 input_parameter_lst=[
@@ -322,7 +322,7 @@ def calculate_elastic_constants_with_minimization_parallel(
                 ],
                 cores=cores,
             )
-        elif isinstance(potential_dataframe_list, DataFrame):
+        elif isinstance(potential_dataframe_list, (DataFrame, Series)):
             return calculate_elastic_constants_with_minimization(
                 lmp=_get_lammps_mpi(enable_mpi=False),
                 structure=structure_list,

--- a/tests/test_parallel_single_core.py
+++ b/tests/test_parallel_single_core.py
@@ -51,14 +51,14 @@ class TestParallelSingleCore(unittest.TestCase):
     def test_example_elastic_constants_parallel_cores_one(self):
         structure_opt_lst = pyr.optimize_structure_parallel(
             structure_list=[self.structure.copy()],
-            potential_dataframe=self.df_pot_selected,
+            potential_dataframe_list=self.df_pot_selected,
             cores=1
         )
 
         # Calculate Elastic Constants
         elastic_matrix = pyr.calculate_elastic_constants_parallel(
             structure_list=structure_opt_lst,
-            potential_dataframe=self.df_pot_selected,
+            potential_dataframe_list=self.df_pot_selected,
             num_of_point=5,
             eps_range=0.005,
             sqrt_eta=True,
@@ -72,7 +72,7 @@ class TestParallelSingleCore(unittest.TestCase):
     def test_example_elastic_constants_with_minimization_parallel_cores_one(self):
         elastic_matrix = pyr.calculate_elastic_constants_with_minimization_parallel(
             structure_list=[self.structure.copy()],
-            potential_dataframe=self.df_pot_selected,
+            potential_dataframe_list=self.df_pot_selected,
             num_of_point=5,
             eps_range=0.005,
             sqrt_eta=True,

--- a/tests/test_parallel_two_cores.py
+++ b/tests/test_parallel_two_cores.py
@@ -51,14 +51,14 @@ class TestParallelTwoCores(unittest.TestCase):
     def test_example_elastic_constants_parallel_cores_two(self):
         structure_opt_lst = pyr.optimize_structure_parallel(
             structure_list=[self.structure.copy()],
-            potential_dataframe=self.df_pot_selected,
+            potential_dataframe_list=[self.df_pot_selected],
             cores=2
         )
 
         # Calculate Elastic Constants
         elastic_matrix = pyr.calculate_elastic_constants_parallel(
             structure_list=structure_opt_lst,
-            potential_dataframe=self.df_pot_selected,
+            potential_dataframe_list=[self.df_pot_selected],
             num_of_point=5,
             eps_range=0.005,
             sqrt_eta=True,
@@ -72,7 +72,7 @@ class TestParallelTwoCores(unittest.TestCase):
     def test_example_elastic_constants_with_minimization_parallel_cores_two(self):
         elastic_matrix = pyr.calculate_elastic_constants_with_minimization_parallel(
             structure_list=[self.structure.copy()],
-            potential_dataframe=self.df_pot_selected,
+            potential_dataframe_list=[self.df_pot_selected],
             num_of_point=5,
             eps_range=0.005,
             sqrt_eta=True,


### PR DESCRIPTION
The `optimize_structure_parallel()`, `calculate_elastic_constants_parallel()` and `calculate_elastic_constants_with_minimization_parallel()` now support both lists of structures and lists interatomic potentials.  