### PR TITLE
Remove conda default channel

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,8 @@ jobs:
       id-token: write
     steps:
     - uses: actions/checkout@v4
+    - name: Conda config
+      run: echo -e "channels:\n  - conda-forge\n" > .condarc
     - uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: "3.12"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,19 +24,14 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: "3.12"
-        mamba-version: "*"
-        channels: conda-forge
-        miniforge-variant: Mambaforge
-        channel-priority: strict
-        auto-update-conda: true
+        miniforge-version: latest
+        condarc-file: .condarc
         environment-file: .ci_support/environment-openmpi.yml
-    - name: Convert dependencies
-      run: |
-        cp .ci_support/environment-old.yml environment.yml
-        python .ci_support/release.py; cat pyproject.toml
     - name: Build
       shell: bash -l {0}
       run: |
+        cp .ci_support/environment-old.yml environment.yml
+        python .ci_support/release.py; cat pyproject.toml
         pip install versioneer[toml]==0.29
         python setup.py sdist bdist_wheel
     - name: Publish distribution 📦 to PyPI

--- a/.github/workflows/pypicheck.yml
+++ b/.github/workflows/pypicheck.yml
@@ -14,14 +14,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Conda config
+      run: echo -e "channels:\n  - conda-forge\n" > .condarc
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: '3.12'
-        miniforge-variant: Mambaforge
-        channels: conda-forge
-        channel-priority: strict
-        activate-environment: my-env
+        miniforge-version: latest
+        condarc-file: .condarc
         environment-file: .ci_support/environment-openmpi.yml
     - name: Pip check
       shell: bash -l {0}

--- a/.github/workflows/unittests-mpich.yml
+++ b/.github/workflows/unittests-mpich.yml
@@ -22,16 +22,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Conda config
+      run: echo -e "channels:\n  - conda-forge\n" > .condarc
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ matrix.python-version }}
-        miniforge-variant: Mambaforge
-        channels: conda-forge
-        channel-priority: strict
-        activate-environment: my-env
+        miniforge-version: latest
+        condarc-file: .condarc
         environment-file: .ci_support/environment-mpich.yml
-        use-mamba: true
     - name: Test
       shell: bash -l {0}
       timeout-minutes: 5

--- a/.github/workflows/unittests-old.yml
+++ b/.github/workflows/unittests-old.yml
@@ -12,16 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Conda config
+      run: echo -e "channels:\n  - conda-forge\n" > .condarc
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: '3.9'
-        miniforge-variant: Mambaforge
-        channels: conda-forge
-        channel-priority: strict
-        activate-environment: my-env
+        miniforge-version: latest
+        condarc-file: .condarc
         environment-file: .ci_support/environment-old.yml
-        use-mamba: true
     - name: Test
       shell: bash -l {0}
       timeout-minutes: 30

--- a/.github/workflows/unittests-openmpi.yml
+++ b/.github/workflows/unittests-openmpi.yml
@@ -26,16 +26,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Conda config
+      run: echo -e "channels:\n  - conda-forge\n" > .condarc
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ matrix.python-version }}
-        miniforge-variant: Mambaforge
-        channels: conda-forge
-        channel-priority: strict
-        activate-environment: my-env
+        miniforge-version: latest
+        condarc-file: .condarc
         environment-file: .ci_support/environment-openmpi.yml
-        use-mamba: true
     - name: Test
       shell: bash -l {0}
       timeout-minutes: 5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a step to configure Conda environments by creating a `.condarc` file, which specifies the `conda-forge` channel for better package management.
	- Updated the setup process for Mambaforge to enhance clarity and control during environment configuration.

- **Bug Fixes**
	- Removed outdated parameters in the Mambaforge setup to streamline the environment management process.

- **Chores**
	- Improved workflows for unit testing and deployment by centralizing Conda channel management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->