### PR TITLE
Change empty dictionary to FileNotFoundError if there's no dump file

### DIFF
--- a/pyiron_lammps/output.py
+++ b/pyiron_lammps/output.py
@@ -196,7 +196,9 @@ def _parse_dump(
             remap_indices_funct=remap_indices_funct,
         )
     else:
-        return {}
+        raise FileNotFoundError(
+            f"Neither {dump_h5_full_file_name} nor {dump_out_full_file_name} exist."
+        )
 
 
 def _collect_dump_from_h5md(file_name: str, prism: UnfoldingPrism) -> Dict:

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -181,14 +181,14 @@ class TestLammpsOutput(unittest.TestCase):
             remap_indices_funct=remap_indices_ase,
         )
         self.assertEqual(len(output_dict["generic"].keys()), 8)
-        output_dump = _parse_dump(
-            dump_h5_full_file_name=os.path.join(self.static_folder, "empty"),
-            dump_out_full_file_name=os.path.join(self.static_folder, "empty"),
-            prism=None,
-            structure=structure_ni,
-            potential_elements=["Ni", "Al", "H"],
-        )
-        self.assertEqual(len(output_dump), 0)
+        with self.assertRaises(FileNotFoundError):
+            _parse_dump(
+                dump_h5_full_file_name=os.path.join(self.static_folder, "empty"),
+                dump_out_full_file_name=os.path.join(self.static_folder, "empty"),
+                prism=None,
+                structure=structure_ni,
+                potential_elements=["Ni", "Al", "H"],
+            )
 
     def test_full_job_output(self):
         test_folder = os.path.join(self.static_folder, "full_job")
@@ -593,3 +593,7 @@ class TestLammpsOutput(unittest.TestCase):
         self.assertTrue("mean_foo" in generic_keys_lst)
         self.assertTrue("mean_bar" in generic_keys_lst)
         self.assertTrue("mean_pressures" in pressure_dict.keys())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I replaced the empty dictionary which is returned by `_parse_dump` by `FileNotFoundError`, because if the file is not found, it anyway raises an error in `parse_lammps_output`, when `dump_dict.pop("steps")` is called, which is more difficult to understand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Clearer error reporting: missing output files now raise a FileNotFoundError instead of returning an empty result, preventing silent failures.
- Tests
  - Updated tests to expect the new error behavior when output files are absent.
  - Added a script entry point to run the test suite directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->