### PR TITLE
Update numpy to 2.3.3 and scipy to 1.16.2

### DIFF
--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -5,6 +5,6 @@ dependencies:
 - hatch-vcs
 - ase =3.26.0
 - h5py =3.14.0
-- numpy =2.3.2
+- numpy =2.3.3
 - pandas =2.3.2
-- scipy =1.16.1
+- scipy =1.16.2

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,9 +3,9 @@ channels:
 dependencies:
 - ase =3.26.0
 - h5py =3.14.0
-- numpy =2.3.2
+- numpy =2.3.3
 - pandas =2.3.2
-- scipy =1.16.1
+- scipy =1.16.2
 - lammps =2024.08.29=*_mpi_openmpi_*
 - hatchling =1.27.0
 - hatch-vcs =0.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,9 @@ classifiers = [
 ]
 dependencies = [
     "ase==3.26.0",
-    "numpy==2.3.2",
+    "numpy==2.3.3",
     "pandas==2.3.2",
-    "scipy==1.16.1",
+    "scipy==1.16.2",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded scientific computing dependencies to latest patch releases: NumPy 2.3.3 and SciPy 1.16.2.
  * Applies across project environments to ensure consistent installs with upstream bug fixes and improved compatibility.
  * No functional changes or user-facing behavior expected; routine maintenance to keep dependencies current.
  * No action required from users—new installations and updates will automatically use the patched versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->