### PR TITLE
Add support for charge atom style

### DIFF
--- a/pyiron_lammps/structure.py
+++ b/pyiron_lammps/structure.py
@@ -198,7 +198,12 @@ class LammpsStructure:
         input_file_name:
     """
 
-    def __init__(self, bond_dict: Optional[Dict] = None, units: str = "metal", atom_type: str = "atomic"):
+    def __init__(
+        self,
+        bond_dict: Optional[Dict] = None,
+        units: str = "metal",
+        atom_type: str = "atomic",
+    ):
         self._string_input: str = ""
         self._structure: Optional[Atoms] = None
         self._potential: Optional[Any] = None

--- a/pyiron_lammps/structure.py
+++ b/pyiron_lammps/structure.py
@@ -198,7 +198,7 @@ class LammpsStructure:
         input_file_name:
     """
 
-    def __init__(self, bond_dict: Optional[Dict] = None, units: str = "metal"):
+    def __init__(self, bond_dict: Optional[Dict] = None, units: str = "metal", atom_type: str = "atomic"):
         self._string_input: str = ""
         self._structure: Optional[Atoms] = None
         self._potential: Optional[Any] = None
@@ -209,6 +209,7 @@ class LammpsStructure:
         self._bond_dict: Optional[Dict] = bond_dict
         self._force_skewed: bool = False
         self._units: str = units
+        self._atom_type: str = atom_type
 
     @property
     def potential(self) -> Any:
@@ -238,7 +239,10 @@ class LammpsStructure:
 
         """
         self._structure = structure
-        input_str = self.structure_atomic()
+        if self._atom_type == "charge":
+            input_str = self.structure_charge()
+        else:  # self.atom_type == 'atomic'
+            input_str = self.structure_atomic()
         self._string_input = input_str + self._get_velocities_input_string()
 
     def _get_velocities_input_string(self) -> str:
@@ -369,6 +373,45 @@ class LammpsStructure:
             atoms += (
                 "{0:d} {1:d} {2:.15f} {3:.15f} {4:.15f}".format(
                     id_atom + 1, species_lammps_id_dict[el], c[0], c[1], c[2]
+                )
+                + "\n"
+            )
+        return (
+            self.lammps_header(
+                structure=self.structure,
+                cell_dimensions=self.simulation_cell(),
+                species_lammps_id_dict=species_lammps_id_dict,
+            )
+            + atoms
+            + "\n"
+        )
+
+    def structure_charge(self):
+        """
+        Create atom structure including the atom charges.
+
+        By convention the LAMMPS atom type numbers are chose alphabetically for the chemical species.
+
+        Returns: LAMMPS readable structure.
+
+        """
+        species_lammps_id_dict = self.get_lammps_id_dict(self.el_eam_lst)
+        atoms = "Atoms\n\n"
+        coords = self.rotate_positions(self._structure)
+        el_charge_lst = self._structure.get_initial_charges()
+        el_lst = self._structure.get_chemical_symbols()
+        for id_atom, (el, coord) in enumerate(zip(el_lst, coords)):
+            dim = self._structure.positions.shape[1]
+            c = np.zeros(3)
+            c[:dim] = coord
+            atoms += (
+                "{0:d} {1:d} {2:f} {3:.15f} {4:.15f} {5:.15f}".format(
+                    id_atom + 1,
+                    species_lammps_id_dict[el],
+                    el_charge_lst[id_atom],
+                    c[0],
+                    c[1],
+                    c[2],
                 )
                 + "\n"
             )

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -226,3 +226,32 @@ class TestLammpsStructure(unittest.TestCase):
         cell[0, 1] = cell[0, 0] * 0.6
         up = UnfoldingPrism(cell=cell)
         self.assertFalse(np.all(np.isclose(up.A, cell)))
+
+    def test_structure_charge(self):
+        atoms = Atoms("Fe1", positions=np.zeros((1, 3)), cell=np.eye(3))
+        atoms.set_initial_charges(charges=np.ones(len(atoms)) * 2.0)
+        lmp_structure = LammpsStructure(atom_type="charge")
+        lmp_structure._el_eam_lst = ["Fe"]
+        lmp_structure.structure = atoms
+        self.assertEqual(
+            lmp_structure._string_input.split("\n"),
+            [
+                "Start File for LAMMPS ",
+                "1 atoms ",
+                "1 atom types ",
+                "",
+                "0. 1.000000000000000 xlo xhi",
+                "0. 1.000000000000000 ylo yhi",
+                "0. 1.000000000000000 zlo zhi",
+                "",
+                "Masses",
+                "",
+                "  1 55.845000  # (Fe) ",
+                "",
+                "Atoms",
+                "",
+                "1 1 2.000000 0.000000000000000 0.000000000000000 0.000000000000000",
+                "",
+                "",
+            ],
+        )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for charge-aware LAMMPS structure generation with configurable `atom_type` parameter, enabling selection between standard "atomic" mode and "charge" mode for per-atom charge handling.

* **Tests**
  * Added test coverage for charge-aware structure generation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->