### PR TITLE
Compatibility interface - handle different types of potentials

### DIFF
--- a/pyiron_lammps/compatibility/file.py
+++ b/pyiron_lammps/compatibility/file.py
@@ -2,8 +2,8 @@ import os
 import subprocess
 from typing import Optional
 
-from ase.atoms import Atoms
 import pandas
+from ase.atoms import Atoms
 
 from pyiron_lammps.compatibility.calculate import (
     calc_md,

--- a/pyiron_lammps/compatibility/file.py
+++ b/pyiron_lammps/compatibility/file.py
@@ -3,6 +3,7 @@ import subprocess
 from typing import Optional
 
 from ase.atoms import Atoms
+import pandas
 
 from pyiron_lammps.compatibility.calculate import (
     calc_md,
@@ -87,9 +88,16 @@ def lammps_file_interface_function(
         calc_kwargs = {}
 
     os.makedirs(working_directory, exist_ok=True)
-    potential_dataframe = get_potential_by_name(
-        potential_name=potential, resource_path=resource_path
-    )
+    if isinstance(potential, str):
+        potential_dataframe = get_potential_by_name(
+            potential_name=potential, resource_path=resource_path
+        )
+    elif isinstance(potential, pandas.DataFrame):
+        potential_dataframe = potential.iloc[0]
+    elif isinstance(potential, pandas.Series):
+        potential_dataframe = potential
+    else:
+        raise TypeError()
     lmp_str_lst = lammps_file_initialization(structure=structure)
     lmp_str_lst += potential_dataframe["Config"]
     lmp_str_lst += ["variable dumptime equal {} ".format(calc_kwargs.get("n_print", 1))]

--- a/tests/test_compatibility_file.py
+++ b/tests/test_compatibility_file.py
@@ -36,6 +36,15 @@ class TestCompatibilityFile(unittest.TestCase):
             shutil.rmtree(self.working_dir)
 
     def test_calc_error(self):
+        with self.assertRaises(TypeError):
+            lammps_file_interface_function(
+                working_directory=self.working_dir,
+                structure=self.structure,
+                potential=1,
+                calc_mode="static",
+                units=self.units,
+                resource_path=os.path.join(self.static_path, "potential"),
+            )
         with self.assertRaises(ValueError):
             lammps_file_interface_function(
                 working_directory=self.working_dir,
@@ -84,7 +93,7 @@ class TestCompatibilityFile(unittest.TestCase):
         shell_output, parsed_output, job_crashed = lammps_file_interface_function(
             working_directory=self.working_dir,
             structure=self.structure,
-            potential= get_potential_by_name(
+            potential=get_potential_by_name(
                 potential_name=self.potential, resource_path=os.path.join(self.static_path, "potential")
             ),
             calc_mode="md",
@@ -134,7 +143,9 @@ class TestCompatibilityFile(unittest.TestCase):
         shell_output, parsed_output, job_crashed = lammps_file_interface_function(
             working_directory=self.working_dir,
             structure=self.structure,
-            potential=self.potential,
+            potential=get_potential_by_name(
+                potential_name=self.potential, resource_path=os.path.join(self.static_path, "potential")
+            ).to_frame(),
             calc_mode="md",
             calc_kwargs=calc_kwargs,
             units=self.units,

--- a/tests/test_compatibility_file.py
+++ b/tests/test_compatibility_file.py
@@ -2,6 +2,7 @@ import unittest
 import os
 import shutil
 from ase.build import bulk
+import pandas
 from pyiron_lammps.compatibility.file import lammps_file_interface_function
 from pyiron_lammps.potential import get_potential_by_name
 
@@ -141,13 +142,14 @@ class TestCompatibilityFile(unittest.TestCase):
             "n_print": 100,
             "langevin": True,
         }
+        potential = get_potential_by_name(
+            potential_name=self.potential,
+            resource_path=os.path.join(self.static_path, "potential"),
+        )
         shell_output, parsed_output, job_crashed = lammps_file_interface_function(
             working_directory=self.working_dir,
             structure=self.structure,
-            potential=get_potential_by_name(
-                potential_name=self.potential,
-                resource_path=os.path.join(self.static_path, "potential"),
-            ).to_frame(),
+            potential=pandas.DataFrame({k: [potential[k]] for k in potential.keys()}),
             calc_mode="md",
             calc_kwargs=calc_kwargs,
             units=self.units,

--- a/tests/test_compatibility_file.py
+++ b/tests/test_compatibility_file.py
@@ -94,7 +94,8 @@ class TestCompatibilityFile(unittest.TestCase):
             working_directory=self.working_dir,
             structure=self.structure,
             potential=get_potential_by_name(
-                potential_name=self.potential, resource_path=os.path.join(self.static_path, "potential")
+                potential_name=self.potential,
+                resource_path=os.path.join(self.static_path, "potential"),
             ),
             calc_mode="md",
             calc_kwargs=calc_kwargs,
@@ -144,7 +145,8 @@ class TestCompatibilityFile(unittest.TestCase):
             working_directory=self.working_dir,
             structure=self.structure,
             potential=get_potential_by_name(
-                potential_name=self.potential, resource_path=os.path.join(self.static_path, "potential")
+                potential_name=self.potential,
+                resource_path=os.path.join(self.static_path, "potential"),
             ).to_frame(),
             calc_mode="md",
             calc_kwargs=calc_kwargs,

--- a/tests/test_compatibility_file.py
+++ b/tests/test_compatibility_file.py
@@ -3,6 +3,7 @@ import os
 import shutil
 from ase.build import bulk
 from pyiron_lammps.compatibility.file import lammps_file_interface_function
+from pyiron_lammps.potential import get_potential_by_name
 
 
 class TestCompatibilityFile(unittest.TestCase):
@@ -83,7 +84,9 @@ class TestCompatibilityFile(unittest.TestCase):
         shell_output, parsed_output, job_crashed = lammps_file_interface_function(
             working_directory=self.working_dir,
             structure=self.structure,
-            potential=self.potential,
+            potential= get_potential_by_name(
+                potential_name=self.potential, resource_path=os.path.join(self.static_path, "potential")
+            ),
             calc_mode="md",
             calc_kwargs=calc_kwargs,
             units=self.units,

--- a/tests/test_compatibility_file.py
+++ b/tests/test_compatibility_file.py
@@ -84,8 +84,9 @@ class TestCompatibilityFile(unittest.TestCase):
         shell_output, parsed_output, job_crashed = lammps_file_interface_function(
             working_directory=self.working_dir,
             structure=self.structure,
-            potential= get_potential_by_name(
-                potential_name=self.potential, resource_path=os.path.join(self.static_path, "potential")
+            potential=get_potential_by_name(
+                potential_name=self.potential,
+                resource_path=os.path.join(self.static_path, "potential"),
             ),
             calc_mode="md",
             calc_kwargs=calc_kwargs,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Potentials may be supplied as a string, a table-like row (DataFrame row), or a series; other types now raise a TypeError.

* **Tests**
  * Test suite updated to validate the new input formats and the TypeError behavior for invalid potential inputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->