### PR TITLE
Use ASE_LAMMPSRUN_COMMAND as a fallback option

### DIFF
--- a/src/lammpsparser/compatibility/file.py
+++ b/src/lammpsparser/compatibility/file.py
@@ -24,7 +24,7 @@ def lammps_file_interface_function(
     calc_mode: str = "static",
     calc_kwargs: Optional[dict] = None,
     units: str = "metal",
-    lmp_command: str = "mpiexec -n 1 --oversubscribe lmp_mpi -in lmp.in",
+    lmp_command: Optional[str] = None,
     resource_path: Optional[str] = None,
     input_control_file: Optional[dict] = None,
     write_restart_file: bool = False,
@@ -92,6 +92,9 @@ def lammps_file_interface_function(
         calc_kwargs = {}
     else:
         calc_kwargs = calc_kwargs.copy()
+
+    if lmp_command is None:
+        lmp_command = os.getenv("ASE_LAMMPSRUN_COMMAND", "mpiexec -n 1 --oversubscribe lmp_mpi") + " -in lmp.in"
 
     os.makedirs(working_directory, exist_ok=True)
     potential_lst, potential_replace, species = _get_potential(

--- a/src/lammpsparser/compatibility/file.py
+++ b/src/lammpsparser/compatibility/file.py
@@ -94,7 +94,10 @@ def lammps_file_interface_function(
         calc_kwargs = calc_kwargs.copy()
 
     if lmp_command is None:
-        lmp_command = os.getenv("ASE_LAMMPSRUN_COMMAND", "mpiexec -n 1 --oversubscribe lmp_mpi") + " -in lmp.in"
+        lmp_command = (
+            os.getenv("ASE_LAMMPSRUN_COMMAND", "mpiexec -n 1 --oversubscribe lmp_mpi")
+            + " -in lmp.in"
+        )
 
     os.makedirs(working_directory, exist_ok=True)
     potential_lst, potential_replace, species = _get_potential(


### PR DESCRIPTION
@Gitdowski As we just discussed the different options to set the LAMMPS executable in the last meeting, this pull request adds the option to specify the LAMMPS executable via the ASE environment variable. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * LAMMPS simulation execution is now more flexible. Users can configure the command through the `ASE_LAMMPSRUN_COMMAND` environment variable, enabling customization for different computing environments and deployment scenarios. Backward compatibility is maintained for existing code that doesn't set the environment variable, ensuring seamless transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->