### PR TITLE
Extract only the last frame from the output

### DIFF
--- a/src/lammpsparser/compatibility/file.py
+++ b/src/lammpsparser/compatibility/file.py
@@ -33,6 +33,7 @@ def lammps_file_interface_function(
     write_restart_file: bool = False,
     read_restart_file: bool = False,
     restart_file: str = "restart.out",
+    last_frame_only: bool = False,
 ):
     """
     A single function to execute a LAMMPS calculation based on the LAMMPS job implemented in pyiron
@@ -236,6 +237,7 @@ def lammps_file_interface_function(
         dump_h5_file_name="dump.h5",
         dump_out_file_name="dump.out",
         log_lammps_file_name="log.lammps",
+        last_frame_only=last_frame_only,
     )
     return shell, output, False
 

--- a/src/lammpsparser/output.py
+++ b/src/lammpsparser/output.py
@@ -169,7 +169,9 @@ def _collect_dump_from_text(
     general purpose routine to extract static from a lammps dump file
     """
     rotation_lammps2orig = prism.R.T
-    dump_lammps_dict = parse_raw_dump_from_text(file_name=file_name, last_frame_only=last_frame_only)
+    dump_lammps_dict = parse_raw_dump_from_text(
+        file_name=file_name, last_frame_only=last_frame_only
+    )
     dump_dict: Dict[str, Any] = {}
     for key, val in dump_lammps_dict.items():
         if key in ["cells"]:

--- a/src/lammpsparser/output.py
+++ b/src/lammpsparser/output.py
@@ -67,6 +67,7 @@ def parse_lammps_output(
     dump_out_file_name: str = "dump.out",
     log_lammps_file_name: str = "log.lammps",
     remap_indices_funct: Callable[..., np.ndarray] = remap_indices_ase,
+    last_frame_only: bool = False,
 ) -> Dict[str, Dict[str, Any]]:
     if prism is None:
         prism = UnfoldingPrism(structure.cell)
@@ -77,6 +78,7 @@ def parse_lammps_output(
         structure=structure,
         potential_elements=potential_elements,
         remap_indices_funct=remap_indices_funct,
+        last_frame_only=last_frame_only,
     )
 
     generic_keys_lst, pressure_dict, df = _parse_log(
@@ -129,6 +131,7 @@ def _parse_dump(
     structure: Atoms,
     potential_elements: Union[np.ndarray, List],
     remap_indices_funct: Callable[..., np.ndarray] = remap_indices_ase,
+    last_frame_only: bool = False,
 ) -> Dict[str, Any]:
     if os.path.isfile(dump_h5_full_file_name):
         if not _check_ortho_prism(prism=prism):
@@ -137,6 +140,7 @@ def _parse_dump(
             )
         return parse_raw_dump_from_h5md(
             file_name=dump_h5_full_file_name,
+            last_frame_only=last_frame_only,
         )
     elif os.path.exists(dump_out_full_file_name):
         return _collect_dump_from_text(
@@ -145,6 +149,7 @@ def _parse_dump(
             structure=structure,
             potential_elements=potential_elements,
             remap_indices_funct=remap_indices_funct,
+            last_frame_only=last_frame_only,
         )
     else:
         raise FileNotFoundError(
@@ -158,12 +163,13 @@ def _collect_dump_from_text(
     structure: Atoms,
     potential_elements: Union[np.ndarray, List],
     remap_indices_funct: Callable[..., np.ndarray] = remap_indices_ase,
+    last_frame_only: bool = False,
 ) -> Dict[str, Any]:
     """
     general purpose routine to extract static from a lammps dump file
     """
     rotation_lammps2orig = prism.R.T
-    dump_lammps_dict = parse_raw_dump_from_text(file_name=file_name)
+    dump_lammps_dict = parse_raw_dump_from_text(file_name=file_name, last_frame_only=last_frame_only)
     dump_dict: Dict[str, Any] = {}
     for key, val in dump_lammps_dict.items():
         if key in ["cells"]:

--- a/src/lammpsparser/output_raw.py
+++ b/src/lammpsparser/output_raw.py
@@ -69,8 +69,12 @@ def parse_raw_dump_from_h5md(file_name: str, last_frame_only: bool = False) -> D
 
     with h5py.File(file_name, mode="r", libver="latest", swmr=True) as h5md:
         sl = slice(-1, None) if last_frame_only else slice(None)
-        positions = [pos_i.tolist() for pos_i in h5md["/particles/all/position/value"][sl]]
-        steps = [steps_i.tolist() for steps_i in h5md["/particles/all/position/step"][sl]]
+        positions = [
+            pos_i.tolist() for pos_i in h5md["/particles/all/position/value"][sl]
+        ]
+        steps = [
+            steps_i.tolist() for steps_i in h5md["/particles/all/position/step"][sl]
+        ]
         forces = [for_i.tolist() for for_i in h5md["/particles/all/force/value"][sl]]
         # following the explanation at: http://nongnu.org/h5md/h5md.html
         cell = [

--- a/src/lammpsparser/output_raw.py
+++ b/src/lammpsparser/output_raw.py
@@ -64,17 +64,18 @@ def to_amat(l_list: Union[np.ndarray, List]) -> List:
     return cell
 
 
-def parse_raw_dump_from_h5md(file_name: str) -> Dict:
+def parse_raw_dump_from_h5md(file_name: str, last_frame_only: bool = False) -> Dict:
     import h5py
 
     with h5py.File(file_name, mode="r", libver="latest", swmr=True) as h5md:
-        positions = [pos_i.tolist() for pos_i in h5md["/particles/all/position/value"]]
-        steps = [steps_i.tolist() for steps_i in h5md["/particles/all/position/step"]]
-        forces = [for_i.tolist() for for_i in h5md["/particles/all/force/value"]]
+        sl = slice(-1, None) if last_frame_only else slice(None)
+        positions = [pos_i.tolist() for pos_i in h5md["/particles/all/position/value"][sl]]
+        steps = [steps_i.tolist() for steps_i in h5md["/particles/all/position/step"][sl]]
+        forces = [for_i.tolist() for for_i in h5md["/particles/all/force/value"][sl]]
         # following the explanation at: http://nongnu.org/h5md/h5md.html
         cell = [
             np.eye(3) * np.array(cell_i.tolist())
-            for cell_i in h5md["/particles/all/box/edges/value"]
+            for cell_i in h5md["/particles/all/box/edges/value"][sl]
         ]
     return {
         "forces": forces,
@@ -84,12 +85,13 @@ def parse_raw_dump_from_h5md(file_name: str) -> Dict:
     }
 
 
-def parse_raw_dump_from_text(file_name: str) -> Dict:
+def parse_raw_dump_from_text(file_name: str, last_frame_only: bool = False) -> Dict:
     """
     Docstring for _parse_dump_from_text
 
     Args:
         file_name (str): The path to the lammps dump file.
+        last_frame_only (bool): If True, only the last frame is returned.
 
     Returns:
         Dict: Parsed dump data.
@@ -205,6 +207,14 @@ def parse_raw_dump_from_text(file_name: str) -> Dict:
                             dump.computes[kk] = []
                         dump.computes[kk].append(df[k].array)
 
+        if last_frame_only:
+            result = asdict(dump)
+            for k, v in result.items():
+                if k == "computes":
+                    result[k] = {ck: cv[-1:] for ck, cv in v.items()}
+                elif isinstance(v, list) and len(v) > 0:
+                    result[k] = v[-1:]
+            return result
         return asdict(dump)
 
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -664,6 +664,43 @@ class TestLammpsOutput(unittest.TestCase):
             # "KinEng" column is not a generic key, so it goes to hdf_lammps
             self.assertIn("KinEng", output["lammps"])
 
+    def test_parse_dump_text_last_frame_only(self):
+        structure = bulk("Al")
+        prism = UnfoldingPrism(cell=structure.cell)
+        output = _parse_dump(
+            dump_h5_full_file_name="",
+            dump_out_full_file_name=os.path.join(
+                self.static_folder, "jagged_dump", "dump.out"
+            ),
+            prism=prism,
+            structure=structure,
+            potential_elements=["Al"],
+            remap_indices_funct=remap_indices_ase,
+            last_frame_only=True,
+        )
+        self.assertEqual(output["steps"], [1])
+        self.assertEqual(len(output["indices"]), 1)
+        self.assertEqual(len(output["cells"]), 1)
+
+    @unittest.skipIf(skip_h5py_test, "h5py not available")
+    def test_parse_dump_h5_last_frame_only(self):
+        structure = bulk("Ni", cubic=True)
+        prism = UnfoldingPrism(cell=structure.cell)
+        output = _parse_dump(
+            dump_h5_full_file_name=os.path.join(
+                self.static_folder, "full_job_h5", "dump.h5"
+            ),
+            dump_out_full_file_name="",
+            prism=prism,
+            structure=structure,
+            potential_elements=["Ni"],
+            remap_indices_funct=remap_indices_ase,
+            last_frame_only=True,
+        )
+        self.assertEqual(len(output["steps"]), 1)
+        self.assertEqual(len(output["cells"]), 1)
+        self.assertEqual(len(output["positions"]), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_output_raw.py
+++ b/tests/test_output_raw.py
@@ -1,9 +1,17 @@
 import unittest
 from src.lammpsparser.output_raw import (
     to_amat,
+    parse_raw_dump_from_h5md,
     parse_raw_dump_from_text,
     parse_raw_lammps_log,
 )
+
+try:
+    import h5py  # noqa: F401
+
+    skip_h5py_test = False
+except ImportError:
+    skip_h5py_test = True
 
 
 class TestOutputRaw(unittest.TestCase):
@@ -51,3 +59,26 @@ class TestOutputRaw(unittest.TestCase):
         self.assertIn("test", data["computes"])
         self.assertEqual(len(data["mean_unwrapped_positions"]), 1)
         self.assertEqual(len(data["computes"]["test"]), 1)
+
+    def test_parse_raw_dump_from_text_last_frame_only(self):
+        data = parse_raw_dump_from_text(
+            "tests/static/jagged_dump/dump.out", last_frame_only=True
+        )
+        self.assertEqual(len(data["steps"]), 1)
+        self.assertEqual(data["steps"][0], 1)
+        self.assertEqual(len(data["cells"]), 1)
+        self.assertEqual(len(data["indices"]), 1)
+        self.assertEqual(len(data["forces"]), 1)
+        self.assertEqual(len(data["velocities"]), 1)
+        self.assertEqual(len(data["positions"]), 1)
+        self.assertEqual(len(data["unwrapped_positions"]), 1)
+
+    @unittest.skipIf(skip_h5py_test, "h5py not available")
+    def test_parse_raw_dump_from_h5md_last_frame_only(self):
+        data = parse_raw_dump_from_h5md(
+            "tests/static/full_job_h5/dump.h5", last_frame_only=True
+        )
+        self.assertEqual(len(data["steps"]), 1)
+        self.assertEqual(len(data["cells"]), 1)
+        self.assertEqual(len(data["forces"]), 1)
+        self.assertEqual(len(data["positions"]), 1)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `last_frame_only` option to LAMMPS output parsing so users can extract only the final simulation frame instead of the full trajectory.

* **Tests**
  * Added/updated unit tests covering the `last_frame_only` behavior for both text and HDF5 dump formats (HDF5 tests skipped if dependency unavailable).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pyiron/lammpsparser/pull/344?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->