### PR TITLE
Extend unit test coverage to 99%, fix bugs found along the way

### DIFF
--- a/src/lammpsparser/compatibility/structure.py
+++ b/src/lammpsparser/compatibility/structure.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Dict, Optional
+from typing import Dict, List, Optional, Union, cast
 
 import numpy as np
 from ase.atoms import Atoms
@@ -17,7 +17,7 @@ class LammpsStructureCompatibility(LammpsStructure):
         atom_type: str = "atomic",
     ):
         super().__init__(bond_dict=bond_dict, units=units, atom_type=atom_type)
-        self._molecule_ids: list[int] = []
+        self._molecule_ids: Optional[List[int]] = []
 
     @property
     def structure(self) -> Optional[Atoms]:
@@ -37,16 +37,27 @@ class LammpsStructureCompatibility(LammpsStructure):
             structure (ase.atoms.Atoms): The structure to serialise.
         """
         self._structure = structure
-        if self.atom_type == "full":
+        if self._atom_type == "full":
             input_str = self.structure_full()
-        elif self.atom_type == "bond":
+        elif self._atom_type == "bond":
             input_str = self.structure_bond()
-        elif self.atom_type == "charge":
+        elif self._atom_type == "charge":
             input_str = self.structure_charge()
-        else:  # self.atom_type == 'atomic'
+        else:  # self._atom_type == 'atomic'
             input_str = self.structure_atomic()
 
         self._string_input = input_str + self._get_velocities_input_string()
+
+    @property
+    def molecule_ids(self) -> Union[List[int], np.ndarray]:
+        """Per-atom molecule IDs; defaults to all atoms in a single molecule."""
+        if self._molecule_ids is None or len(self._molecule_ids) == 0:
+            return np.ones(len(cast(Atoms, self._structure)), dtype=int)
+        return self._molecule_ids
+
+    @molecule_ids.setter
+    def molecule_ids(self, molecule_ids: Optional[List[int]]):
+        self._molecule_ids = molecule_ids
 
     def structure_bond(self):
         """
@@ -120,7 +131,7 @@ class LammpsStructureCompatibility(LammpsStructure):
                 bond_type[i, j] = count
                 bond_type[j, i] = count
 
-        if self.structure.bonds is None:
+        if getattr(self.structure, "bonds", None) is None:
             if self.cutoff_radius is None:
                 bonds_lst = get_bonds(structure=self.structure, max_shells=1)
             else:
@@ -182,16 +193,22 @@ class LammpsStructureCompatibility(LammpsStructure):
         coords = self.rotate_positions(self._structure)
 
         # extract electric charges from potential file
-        q_dict = {
-            species_name: self.potential.get_charge(species_name)
-            for species_name in set(self.structure.get_chemical_symbols())
-        }
+        if self.potential is not None:
+            q_dict = {
+                species_name: self.potential.get_charge(species_name)
+                for species_name in set(self.structure.get_chemical_symbols())
+            }
+        else:
+            q_dict = {
+                species_name: 0.0
+                for species_name in set(self.structure.get_chemical_symbols())
+            }
 
         bonds_lst, angles_lst = [], []
         bond_type_lst, angle_type_lst = [], []
         # Using a cutoff distance to draw the bonds instead of the number of neighbors
         # Only if any bonds are defined
-        if len(self._bond_dict.keys()) > 0:
+        if self._bond_dict is not None and len(self._bond_dict.keys()) > 0:
             cutoff_list = list()
             for val in self._bond_dict.values():
                 cutoff_list.append(np.max(val["cutoff_list"]))
@@ -350,7 +367,6 @@ def get_bonds(
         tolerance=2,
         id_list=None,
         width_buffer=1.2,
-        allow_ragged=None,
         mode="ragged",
         norm_order=2,
     )

--- a/tests/static/log_with_warning/log.lammps
+++ b/tests/static/log_with_warning/log.lammps
@@ -1,0 +1,8 @@
+LAMMPS (27 Jun 2024)
+units metal
+Step Temp PotEng TotEng Volume
+0 0 -17.800000050373 -17.800000050373 43.614208
+WARNING: Energy is not conserved
+1 0 -17.700000050373 -17.700000050373 43.614208
+Loop time of 1.302e-06 on 1 procs for 1 steps with 4 atoms
+Total wall time: 0:00:00

--- a/tests/test_compatibility_structure.py
+++ b/tests/test_compatibility_structure.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 import numpy as np
 from ase.build import bulk
 from ase.atoms import Atoms
@@ -44,6 +45,17 @@ class TestLammpsStructureCompatibilityInit(unittest.TestCase):
         lsc._structure = structure
         self.assertIs(lsc.structure, structure)
 
+    def test_molecule_ids_default(self):
+        lsc = LammpsStructureCompatibility()
+        lsc._structure = bulk("Al", a=4.0, cubic=True)
+        np.testing.assert_array_equal(lsc.molecule_ids, np.ones(4, dtype=int))
+
+    def test_molecule_ids_explicit(self):
+        lsc = LammpsStructureCompatibility()
+        lsc._structure = bulk("Al", a=4.0, cubic=True)
+        lsc.molecule_ids = [1, 1, 2, 2]
+        self.assertEqual(lsc.molecule_ids, [1, 1, 2, 2])
+
 
 @unittest.skipIf(skip_structuretoolkit_test, "structuretoolkit not available")
 class TestLammpsStructureCompatibilitySetterAtomic(unittest.TestCase):
@@ -69,16 +81,124 @@ class TestLammpsStructureCompatibilitySetterAtomic(unittest.TestCase):
 
 
 @unittest.skipIf(skip_structuretoolkit_test, "structuretoolkit not available")
+class TestLammpsStructureCompatibilitySetterBond(unittest.TestCase):
+    def test_structure_setter_bond(self):
+        lsc = LammpsStructureCompatibility(atom_type="bond")
+        lsc.atom_type = "bond"
+        lsc.el_eam_lst = ["Al"]
+        structure = bulk("Al", a=4.05, cubic=True).repeat([2, 2, 2])
+        lsc.structure = structure
+        self.assertIs(lsc._structure, structure)
+        self.assertIn("Bonds", lsc._string_input)
+
+    def test_structure_setter_bond_cutoff_radius(self):
+        lsc = LammpsStructureCompatibility(atom_type="bond")
+        lsc.atom_type = "bond"
+        lsc.el_eam_lst = ["Al"]
+        lsc.cutoff_radius = 3.0
+        structure = bulk("Al", a=4.05, cubic=True).repeat([2, 2, 2])
+        lsc.structure = structure
+        self.assertIn("Bonds", lsc._string_input)
+
+    def test_structure_setter_bond_2d(self):
+        # ASE Atoms always stores 3-column positions, so the 2D branch is
+        # only reachable via a duck-typed structure (mirrors the pattern in
+        # test_structure.py's two-dimensional-positions test).
+        class _Dummy2D:
+            def __init__(self):
+                self.positions = np.zeros((2, 2))
+                self.cell = np.eye(3) * 5.0
+                self.bonds = np.array([[1, 2, 1]])
+
+            def get_chemical_symbols(self):
+                return ["Fe", "Fe"]
+
+            def get_volume(self):
+                return float(np.linalg.det(self.cell))
+
+            def __len__(self):
+                return 2
+
+        lsc = LammpsStructureCompatibility(atom_type="bond")
+        lsc.el_eam_lst = ["Fe"]
+        lsc._structure = _Dummy2D()
+        with patch.object(
+            LammpsStructureCompatibility,
+            "rotate_positions",
+            return_value=[(0.0, 0.0), (1.0, 1.0)],
+        ):
+            result = lsc.structure_bond()
+        self.assertIn("Bonds", result)
+
+    def test_structure_setter_bond_1d_raises(self):
+        class _Dummy1D:
+            def __init__(self):
+                self.positions = np.zeros((2, 1))
+
+            def get_chemical_symbols(self):
+                return ["Fe", "Fe"]
+
+        lsc = LammpsStructureCompatibility(atom_type="bond")
+        lsc.el_eam_lst = ["Fe"]
+        lsc._structure = _Dummy1D()
+        with patch.object(
+            LammpsStructureCompatibility,
+            "rotate_positions",
+            return_value=[(0.0,), (1.0,)],
+        ):
+            with self.assertRaises(ValueError):
+                lsc.structure_bond()
+
+
+@unittest.skipIf(skip_structuretoolkit_test, "structuretoolkit not available")
+class TestLammpsStructureCompatibilitySetterFull(unittest.TestCase):
+    def test_structure_setter_full_no_potential(self):
+        lsc = LammpsStructureCompatibility(atom_type="full")
+        lsc.atom_type = "full"
+        lsc.el_eam_lst = ["Al"]
+        structure = bulk("Al", a=4.05, cubic=True)
+        lsc.structure = structure
+        self.assertIs(lsc._structure, structure)
+        self.assertIn("Atoms", lsc._string_input)
+
+    def test_structure_setter_full_with_potential_bonds_angles(self):
+        class _DummyPotential:
+            def get_charge(self, species_name):
+                return 1.5
+
+        lsc = LammpsStructureCompatibility(
+            bond_dict={
+                "Al": {
+                    "element_list": ["Al"],
+                    "cutoff_list": [3.0],
+                    "max_bond_list": [2],
+                    "bond_type_list": [1],
+                    "angle_type_list": [2],
+                }
+            },
+            atom_type="full",
+        )
+        lsc.atom_type = "full"
+        lsc.el_eam_lst = ["Al"]
+        lsc.potential = _DummyPotential()
+        structure = bulk("Al", a=4.05, cubic=True).repeat([2, 2, 2])
+        lsc.structure = structure
+        self.assertIn("Bonds", lsc._string_input)
+        self.assertIn("Angles", lsc._string_input)
+        self.assertIn("1.500000", lsc._string_input)
+
+
+@unittest.skipIf(skip_structuretoolkit_test, "structuretoolkit not available")
 class TestGetBonds(unittest.TestCase):
-    def test_get_bonds_error(self):
+    def test_get_bonds_default(self):
         structure = bulk("Al", a=4.05, cubic=True).repeat([2, 2, 1])
-        # get_bonds may fail due to incompatible structuretoolkit version;
-        # either result or TypeError is acceptable
-        try:
-            result = get_bonds(structure=structure, max_shells=1)
-            self.assertIsNotNone(result)
-        except TypeError:
-            pass
+        result = get_bonds(structure=structure, max_shells=1)
+        self.assertEqual(len(result), len(structure))
+
+    def test_get_bonds_radius(self):
+        structure = bulk("Al", a=4.05, cubic=True).repeat([2, 2, 1])
+        result = get_bonds(structure=structure, radius=3.0)
+        self.assertEqual(len(result), len(structure))
 
 
 if __name__ == "__main__":

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -4,6 +4,7 @@ from ase.build import bulk
 from ase.constraints import FixAtoms, FixCom, FixedPlane
 
 from lammpsparser.compatibility.constraints import (
+    _get_fixed_atom_boolean_vector,
     set_selective_dynamics,
 )
 
@@ -169,3 +170,23 @@ class TestConstraints(unittest.TestCase):
         )
         with self.assertRaises(ValueError):
             set_selective_dynamics(structure=atoms, calc_md=False)
+
+    def test_fixed_plane_legacy_a_kwarg(self):
+        # Older ASE releases named the FixedPlane constructor argument "a"
+        # instead of "indices"; todict() for such an object would report
+        # the constraint under the "a" key. Exercise that branch directly
+        # with a duck-typed constraint, since the installed ASE version no
+        # longer produces this shape.
+        class _LegacyFixedPlane:
+            def todict(self):
+                return {
+                    "name": "FixedPlane",
+                    "kwargs": {"a": 2, "direction": [1, 0, 0]},
+                }
+
+        atoms = self.structure.copy()
+        atoms.constraints = [_LegacyFixedPlane()]
+        fixed_atom_vector = _get_fixed_atom_boolean_vector(atoms)
+        self.assertTrue(fixed_atom_vector[2][0])
+        self.assertFalse(fixed_atom_vector[2][1])
+        self.assertFalse(fixed_atom_vector[2][2])

--- a/tests/test_output_raw.py
+++ b/tests/test_output_raw.py
@@ -42,6 +42,11 @@ class TestOutputRaw(unittest.TestCase):
         self.assertEqual(len(df), 1)
         self.assertNotIn("Press", df.columns)
 
+    def test_parse_raw_lammps_log_warning(self):
+        with self.assertWarns(UserWarning):
+            df = parse_raw_lammps_log("tests/static/log_with_warning/log.lammps")
+        self.assertEqual(len(df), 2)
+
     def test_parse_raw_dump_from_text_mean_fields(self):
         data = parse_raw_dump_from_text("tests/static/mean_dump/dump.out")
         self.assertEqual(len(data["steps"]), 1)

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -57,6 +57,23 @@ class TestPotential(unittest.TestCase):
         )
         self.assertEqual(df.Name, "1999--Mishin-Y--Al--LAMMPS--ipr1")
 
+    @mock.patch("lammpsparser.potential.get_resource_path_from_conda")
+    def test_get_potential_dataframe_resource_path_from_conda(self, mock_conda):
+        mock_conda.return_value = self.resource_path
+        df = get_potential_dataframe(structure=bulk("Al"), resource_path=None)
+        mock_conda.assert_called_once()
+        self.assertEqual(len(df), 1)
+
+    @mock.patch("lammpsparser.potential.get_resource_path_from_conda")
+    def test_get_potential_by_name_resource_path_from_conda(self, mock_conda):
+        mock_conda.return_value = self.resource_path
+        df = get_potential_by_name(
+            potential_name="1999--Mishin-Y--Al--LAMMPS--ipr1",
+            resource_path=None,
+        )
+        mock_conda.assert_called_once()
+        self.assertEqual(df.Name, "1999--Mishin-Y--Al--LAMMPS--ipr1")
+
     def test_convert_path_to_abs_posix(self):
         self.assertEqual(
             convert_path_to_abs_posix(path="~/test"),
@@ -238,3 +255,7 @@ class TestPotentialAvailable(unittest.TestCase):
 
     def test_get_attr(self):
         self.assertEqual(str(self.available.pot_pot1), "pot1")
+
+    def test_get_attr_missing(self):
+        with self.assertRaises(AttributeError):
+            self.available.pot_does_not_exist


### PR DESCRIPTION
## Summary

`lammpsparser.compatibility.structure` sat at 20% coverage because its `bond`/`full` atom-style code paths crash as soon as they're actually exercised. Writing real tests for them required fixing the underlying bugs first:

- `LammpsStructureCompatibility.structure`'s setter dispatched on `self.atom_type` (never set) instead of `self._atom_type`, so it always fell through to the atomic/charge branch regardless of the requested style.
- `molecule_ids` was assigned `None` with no property to supply a default, so indexing it crashed with `TypeError`.
- `self.structure.bonds` was read unconditionally, but plain `ase.Atoms` has no such attribute (`AttributeError`); switched to `getattr(..., None)`.
- `structure_full` crashed when no `potential`/`bond_dict` was set instead of falling back to zero charges / no bonds.
- `get_bonds` passed `allow_ragged` to `structuretoolkit.get_neighbors`, which the pinned `structuretoolkit` version no longer accepts.

(Note: a prior automated attempt at this exact fix exists in closed PR #336 — this PR re-derives the same fixes independently with its own test suite.)

With those fixed, added tests for:
- `structure_bond`/`structure_full` bond/full atom styles, including `bond_dict`-driven bonds/angles, `cutoff_radius`, and the 2D/1D dimension branches (via duck-typed structures, mirroring the existing pattern in `test_structure.py`)
- the legacy `FixedPlane` `"a"`-kwarg branch in `compatibility.constraints`
- the `WARNING:`-line branch in `parse_raw_lammps_log`
- missing-attribute lookups on `PotentialAvailable`
- `resource_path=None` fallback to conda detection in `potential.py`

Overall coverage moves from 90% to 99%. The remaining 9 lines are floating-point edge-case corrections inside `UnfoldingPrism` that are mathematically unreachable through any realistic cell geometry (only triggerable by engineered float-precision boundary cases), so no test was added for them rather than writing a brittle one purely to chase the number.

## Test plan
- [x] `pytest` — 145 passed (1 pre-existing, environment-specific integration test failure unrelated to this change: real LAMMPS+MPI segfault on this machine, also fails on `main`)
- [x] `coverage run -m pytest && coverage report` — 99% overall
- [x] `pre-commit run` (ruff lint + format) — passed
- [x] `mypy --ignore-missing-imports src/lammpsparser` — no new errors (2 pre-existing errors unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility handling for molecule IDs, bond generation, and charge assignment in structures.
  * Better support for legacy constraint input formats and safer handling of missing bond data.
  * Parsing LAMMPS logs now correctly handles warning messages and returns the expected output.
  * Potential lookup and resource path resolution are more robust, including missing-entry handling.
* **Tests**
  * Expanded test coverage for structure, constraints, log parsing, and potential selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->