### PR TITLE
Add n_print_dump and n_print_thermo to control dump/thermo intervals independently

### DIFF
--- a/src/lammpsparser/compatibility/file.py
+++ b/src/lammpsparser/compatibility/file.py
@@ -34,6 +34,8 @@ def lammps_file_interface_function(
     read_restart_file: bool = False,
     restart_file: str = "restart.out",
     dump_final_structure: bool = False,
+    n_print_dump: Optional[int] = None,
+    n_print_thermo: Optional[int] = None,
 ):
     """
     A single function to execute a LAMMPS calculation based on the LAMMPS job interface implemented in lammpsparser
@@ -88,6 +90,13 @@ def lammps_file_interface_function(
         restart_file (str): file name of the LAMMPS restart file to copy
         dump_final_structure (bool): in "md" mode, append a ``write_dump`` command after the ``run`` command to capture
             the final structure in ``dump.out`` if last step is not a regular dump step. Disabled by default.
+        n_print_dump (int, optional): Override the dump-file write interval (steps between successive
+            ``dump`` writes), independently of ``calc_kwargs["n_print"]``. Defaults to ``None``, which
+            falls back to ``calc_kwargs.get("n_print", 1)`` (the pre-existing behavior).
+        n_print_thermo (int, optional): Override the thermodynamic print interval (steps between
+            successive ``thermo`` output lines), independently of ``calc_kwargs["n_print"]``. Defaults
+            to ``None``, which leaves ``calc_kwargs["n_print"]`` untouched (the pre-existing behavior).
+            Has no effect in ``"static"`` mode, since that mode only ever performs a single step.
         executable_version (str): LAMMPS version to for the execution
         executable_path (str): path to the LAMMPS executable
         input_control_file (str|list|dict): Option to modify the LAMMPS input file directly
@@ -112,6 +121,12 @@ def lammps_file_interface_function(
         calc_kwargs = {}
     else:
         calc_kwargs = calc_kwargs.copy()
+
+    dump_interval = (
+        n_print_dump if n_print_dump is not None else calc_kwargs.get("n_print", 1)
+    )
+    if n_print_thermo is not None:
+        calc_kwargs["n_print"] = n_print_thermo
 
     if lmp_command is None:
         lmp_command = (
@@ -148,7 +163,7 @@ def lammps_file_interface_function(
     dump_format = '"%d %d %20.15g %20.15g %20.15g %20.15g %20.15g %20.15g %20.15g %20.15g %20.15g"'
 
     lmp_str_lst += potential_lst
-    lmp_str_lst += ["variable dumptime equal {} ".format(calc_kwargs.get("n_print", 1))]
+    lmp_str_lst += ["variable dumptime equal {} ".format(dump_interval)]
     lmp_str_lst += [
         "dump 1 all custom ${dumptime} dump.out " + dump_fields,
         "dump_modify 1 sort id format line " + dump_format,
@@ -193,7 +208,7 @@ def lammps_file_interface_function(
         if read_restart_file:
             lmp_str_lst += ["reset_timestep 0"]
         lmp_str_lst += ["run {} ".format(n_ionic_steps)]
-        last_step_is_regular_dump = n_ionic_steps % calc_kwargs.get("n_print", 1) == 0
+        last_step_is_regular_dump = n_ionic_steps % dump_interval == 0
         if dump_final_structure and not last_step_is_regular_dump:
             lmp_str_lst += [
                 "write_dump all custom dump.out "

--- a/tests/test_compatibility_file.py
+++ b/tests/test_compatibility_file.py
@@ -752,6 +752,124 @@ class TestCompatibilityFile(unittest.TestCase):
         for line in content_expected:
             self.assertIn(line, content)
 
+    def test_n_print_dump_override_md(self):
+        md_input = CalcMDInput(
+            temperature=500.0,
+            pressure=0.0,
+            n_ionic_steps=1000,
+            n_print=100,
+        )
+        shell_output, parsed_output, job_crashed = lammps_file_interface_function(
+            working_directory=self.working_dir,
+            structure=self.structure,
+            potential=self.potential,
+            calc_dataclass=md_input,
+            units=self.units,
+            lmp_command="cp "
+            + str(os.path.join(self.static_path, "compatibility_output"))
+            + "/* .",
+            resource_path=os.path.join(self.static_path, "potential"),
+            n_print_dump=50,
+        )
+        self.assertFalse(job_crashed)
+        with open(self.working_dir + "/lmp.in", "r") as f:
+            content = f.readlines()
+        self.assertIn("variable dumptime equal 50 \n", content)
+        self.assertIn("variable thermotime equal 100 \n", content)
+
+    def test_n_print_thermo_override_md(self):
+        md_input = CalcMDInput(
+            temperature=500.0,
+            pressure=0.0,
+            n_ionic_steps=1000,
+            n_print=100,
+        )
+        shell_output, parsed_output, job_crashed = lammps_file_interface_function(
+            working_directory=self.working_dir,
+            structure=self.structure,
+            potential=self.potential,
+            calc_dataclass=md_input,
+            units=self.units,
+            lmp_command="cp "
+            + str(os.path.join(self.static_path, "compatibility_output"))
+            + "/* .",
+            resource_path=os.path.join(self.static_path, "potential"),
+            n_print_thermo=25,
+        )
+        self.assertFalse(job_crashed)
+        with open(self.working_dir + "/lmp.in", "r") as f:
+            content = f.readlines()
+        self.assertIn("variable dumptime equal 100 \n", content)
+        self.assertIn("variable thermotime equal 25 \n", content)
+
+    def test_n_print_dump_and_thermo_override_together(self):
+        md_input = CalcMDInput(
+            temperature=500.0,
+            pressure=0.0,
+            n_ionic_steps=1000,
+            n_print=100,
+        )
+        shell_output, parsed_output, job_crashed = lammps_file_interface_function(
+            working_directory=self.working_dir,
+            structure=self.structure,
+            potential=self.potential,
+            calc_dataclass=md_input,
+            units=self.units,
+            lmp_command="cp "
+            + str(os.path.join(self.static_path, "compatibility_output"))
+            + "/* .",
+            resource_path=os.path.join(self.static_path, "potential"),
+            n_print_dump=10,
+            n_print_thermo=20,
+        )
+        self.assertFalse(job_crashed)
+        with open(self.working_dir + "/lmp.in", "r") as f:
+            content = f.readlines()
+        self.assertIn("variable dumptime equal 10 \n", content)
+        self.assertIn("variable thermotime equal 20 \n", content)
+
+    def test_n_print_dump_and_thermo_override_minimize(self):
+        minimize_input = CalcMinimizeInput(
+            n_print=100,
+            max_iter=200,
+        )
+        shell_output, parsed_output, job_crashed = lammps_file_interface_function(
+            working_directory=self.working_dir,
+            structure=self.structure,
+            potential=self.potential,
+            calc_dataclass=minimize_input,
+            units=self.units,
+            lmp_command="cp "
+            + str(os.path.join(self.static_path, "compatibility_output"))
+            + "/* .",
+            resource_path=os.path.join(self.static_path, "potential"),
+            n_print_dump=5,
+            n_print_thermo=15,
+        )
+        self.assertFalse(job_crashed)
+        with open(self.working_dir + "/lmp.in", "r") as f:
+            content = f.readlines()
+        self.assertIn("variable dumptime equal 5 \n", content)
+        self.assertIn("variable thermotime equal 15 \n", content)
+
+    def test_n_print_thermo_noop_static_mode(self):
+        shell_output, parsed_output, job_crashed = lammps_file_interface_function(
+            working_directory=self.working_dir,
+            structure=self.structure,
+            potential=self.potential,
+            calc_mode="static",
+            units=self.units,
+            lmp_command="cp "
+            + str(os.path.join(self.static_path, "compatibility_output"))
+            + "/* .",
+            resource_path=os.path.join(self.static_path, "potential"),
+            n_print_thermo=42,
+        )
+        self.assertFalse(job_crashed)
+        with open(self.working_dir + "/lmp.in", "r") as f:
+            content = f.readlines()
+        self.assertIn("variable thermotime equal 1\n", content)
+
 
 class TestGlassPotential(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
`lammps_file_interface_function()` previously derived both the dump-file write interval and the thermodynamic print interval from the single `n_print` key in `calc_kwargs`. These new optional parameters let callers override each independently, defaulting to the existing behavior when left unset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added independent controls for dump output intervals and thermo output intervals.
  * Supports configuring these intervals separately for molecular dynamics and minimization runs.
  * Thermo interval overrides are ignored in static mode, preserving existing behavior.

* **Tests**
  * Added coverage for dump and thermo interval combinations across supported run modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->